### PR TITLE
Remove poetry from docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Removed poetry from docker image of action
+- Use python slim as base Docker image instead of alpine
+
+
+## [0.1.0]
+
 ### Added
 - Initial commit of UMM-S updater Github Action
 ### Changed 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,19 @@
 # Container image that runs your code
-FROM python:3.9.7-alpine
+FROM python:3.9-slim
 
-RUN apk add --no-cache bash jq curl gcc
+RUN apt-get update \
+    && apt-get install -y jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
-
-# Set env vars needed for poetry installation
-ENV PYTHONUNBUFFERED=1 \
-    # prevents python creating .pyc files
-    PYTHONDONTWRITEBYTECODE=1 \
-    \
-    # pip
-    PIP_NO_CACHE_DIR=off \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PIP_DEFAULT_TIMEOUT=100 \
-    \
-    # poetry
-    # https://python-poetry.org/docs/configuration/#using-environment-variables
-    POETRY_VERSION=1.1.4 \
-    # make poetry install to this location
-    POETRY_HOME="/opt/poetry" \
-    # make poetry create the virtual environment in the project's root
-    # it gets named `.venv`
-    POETRY_VIRTUALENVS_IN_PROJECT=true \
-    # do not ask any interactive question
-    POETRY_NO_INTERACTION=1 \
-    \
-    # paths
-    # this is where our requirements + virtual environment will live
-    PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv"
-ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
-
-# Install poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 
 # Copy source into container
 RUN mkdir /podaac-umm-publisher
 COPY . .
 
 # Install umm updater tool
-RUN poetry install 
+RUN python -m pip install --upgrade pip && pip install . 
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,6 @@ if [[ $env == "sit" || $env == "uat" ]]; then
   jq --arg a "https://harmony.uat.earthdata.nasa.gov" '.URL.URLValue = $a' cmr/cmr.json > cmr/cmr.json.tmp && mv cmr/cmr.json.tmp cmr/cmr.json
 fi
 
-poetry run umms_updater -d -f cmr/cmr.json -a cmr/${env}_associations.txt -p POCLOUD -e ${env} -cu $cmr_user -cp $cmr_pass
+umms_updater -d -f cmr/cmr.json -a cmr/${env}_associations.txt -p POCLOUD -e ${env} -cu $cmr_user -cp $cmr_pass
 
 set -x


### PR DESCRIPTION
Don't need poetry in the docker image. Also use slim instead of alpine.

Tested by building docker container locally and was able to get the help message from umms_updater when running the image.